### PR TITLE
Remove mu-plugins/pantheon* from rsync excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
+## [v1.0.1] - 2024-06-13
+
+### Changed
+
+- Remove `mu-plugins/pantheon*` from the `rsync` excludes in order to version control de Pantheon MU-Plugins (#12)
+
 ## [v1.0.0] - 2024-04-22
+
 ### Added
-- Initial action release.
+
+- Initial action release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ### Changed
 
-- Remove `mu-plugins/pantheon*` from the `rsync` excludes in order to version control de Pantheon MU-Plugins (#12)
+- Remove `mu-plugins/pantheon*` from the `rsync` excludes in order to version control the Pantheon MU-Plugins (#12)
 
 ## [v1.0.0] - 2024-04-22
 

--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Deploy to Pantheon
-      - name: Deploy to Pantheon
+      - name: Promote Test to Live
         uses: 10up/pantheon-wp-deploy-action@v1
         with:
           pantheon_git_url: "${{ secrets.PANTHEON_GIT_URL }}"
@@ -182,7 +181,7 @@ jobs:
 
 ## Changelog
 
-A complete listing of all notable changes to ElasticPress Labs are documented in [CHANGELOG.md](https://github.com/10up/pantheon-wp-deploy-action/blob/trunk/CHANGELOG.md).
+A complete listing of all notable changes to this Github Action are documented in [CHANGELOG.md](https://github.com/10up/pantheon-wp-deploy-action/blob/trunk/CHANGELOG.md).
 
 ## Contributing
 

--- a/image/entrypoint.sh
+++ b/image/entrypoint.sh
@@ -67,7 +67,6 @@ fi
 
 rsync -vrxc --delete --force "${RSYNC_SOURCE_DIR}"/wp-content/ /tmp/site/wp-content/ \
   --exclude=uploads \
-  --exclude=mu-plugins/pantheon* \
   --exclude=wp-content/db.php \
   --exclude=wp-content/pantheon.php
 


### PR DESCRIPTION
### Description of the Change
Remove `mu-plugins/pantheon*` from the `rsync` excludes in order to version control the Pantheon MU-Plugins

Closes #12 

### Changelog Entry
* Remove `mu-plugins/pantheon*` from `rsync` excludes
* Small documentation fixes

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
